### PR TITLE
Allow files.upload action to send multipart/form-data files

### DIFF
--- a/actions/run.py
+++ b/actions/run.py
@@ -18,16 +18,20 @@ class SlackAction(Action):
 
     def _get_request(self, params):
         end_point = params['end_point']
+        files = None
         url = urlparse.urljoin(BASE_URL, end_point)
         del params['end_point']
 
         headers = {}
-        headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        if end_point == "files.upload" and params['file']:
+            files = {'file': open(params['file'], 'rb')}
+            del params['file']
+        else:
+            headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
         data = urllib.urlencode(params)
         self.logger.info(data)
-        response = requests.get(url=url,
-                                headers=headers, params=data)
+        response = requests.post(url=url, headers=headers, params=data, files=files)
 
         results = response.json()
         if not results['ok']:

--- a/actions/run.py
+++ b/actions/run.py
@@ -23,7 +23,7 @@ class SlackAction(Action):
         del params['end_point']
 
         headers = {}
-        if end_point == "files.upload" and params['file']:
+        if end_point == "files.upload" and params.get('file', None):
             files = {'file': open(params['file'], 'rb')}
             del params['file']
         else:


### PR DESCRIPTION
Currently only `content`-based `file.upload` requests can be uploaded. This is because the API call is a hard-coded `application/x-www-form-urlencoded` `get` request.

This PR addresses the issue and properly packages `file` payload in the `requests.post` `files` parameter.  This triggers `requests` to use the proper content-type `multipart/form-data` header, and also properly sends the file data.

Even though the request method has changed from `get` to `post` the other API methods work normally.